### PR TITLE
fix/evidence runs 404

### DIFF
--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -32,9 +32,9 @@ jobs:
           else
             TAG="$(gh release view -R "$REPO" --json tagName --jq .tagName)"
           fi
-          PREV="$(gh api repos/$REPO/releases \
-            --jq 'map(select(.draft==false))|sort_by(.created_at)|reverse|.[1].tag_name // ""')"
-          # Resolve the commit SHA behind the tag (handles annotated tags)
+          PREV="$(gh api repos/$REPO/releases --paginate \
+            --jq '[.[]|select(.draft==false)]|sort_by(.created_at)|reverse|.[1].tag_name // ""')"
+          # IMPORTANT: resolve the *commit* SHA behind the tag (works for annotated & lightweight)
           SHA="$(gh api repos/$REPO/commits/$TAG --jq .sha)"
           echo "tag=$TAG"  >> "$GITHUB_OUTPUT"
           echo "prev=$PREV" >> "$GITHUB_OUTPUT"
@@ -52,6 +52,7 @@ jobs:
           set -euo pipefail
           OUT="release-evidence-$TAG.md"
 
+          # Pull core release fields via gh release view (robust by tag)
           gh release view "$TAG" -R "$REPO" \
             --json name,tagName,publishedAt,author,url > /tmp/release.json
 
@@ -74,8 +75,16 @@ jobs:
             fi
             echo
             echo "## Workflow runs for $TAG"
-            gh api "repos/$REPO/actions/runs" -f head_sha="$SHA" \
-              --jq '.workflow_runs[] | "* \(.name) • conclusion: \(.conclusion // .status) • run_id=\(.id)"'
+            # Use CLI list (more reliable than raw REST here); filter by headSha == commit SHA
+            RUNS="$(gh run list -R "$REPO" --limit 100 \
+                    --json name,conclusion,status,headSha,databaseId \
+                  | jq -r --arg SHA "$SHA" \
+                      '.[] | select(.headSha==$SHA) | "* \(.name) • conclusion: \(.conclusion // .status) • run_id=\(.databaseId)"')"
+            if [ -n "$RUNS" ]; then
+              echo "$RUNS"
+            else
+              echo "* No matching workflow runs for commit $SHA"
+            fi
           } > "$OUT"
 
           echo "out=$OUT" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/release-evidence.yml
+++ b/.github/workflows/release-evidence.yml
@@ -1,12 +1,12 @@
 name: Release Evidence
+
 on:
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       tag:
-        description: "Release tag (optional; defaults to latest)"
+        description: Tag to generate evidence for (defaults to latest release)
         required: false
+
 permissions:
   contents: write
   actions: read
@@ -14,48 +14,46 @@ permissions:
 jobs:
   evidence:
     runs-on: ubuntu-latest
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+        with:
+          fetch-depth: 0
 
       - name: Resolve tag/prev/sha
         id: meta
+        env:
+          REPO: ${{ github.repository }}
+          TAG_INPUT: ${{ github.event.inputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
-          REPO="${GITHUB_REPOSITORY}"
-          TAG_INPUT="${{ github.event.inputs.tag || '' }}"
-          if [ -n "$TAG_INPUT" ]; then
+          if [ -n "${TAG_INPUT:-}" ]; then
             TAG="$TAG_INPUT"
           else
-            TAG="${{ github.event.release.tag_name }}"
-          fi
-          if [ -z "${TAG:-}" ]; then
             TAG="$(gh release view -R "$REPO" --json tagName --jq .tagName)"
           fi
-          PREV="$(gh api repos/$REPO/releases --paginate --jq '[.[]|select(.draft==false)]|sort_by(.created_at)|reverse|.[1].tag_name // ""')"
-          SHA="$(gh api repos/$REPO/git/ref/tags/$TAG --jq .object.sha)"
+          PREV="$(gh api repos/$REPO/releases \
+            --jq 'map(select(.draft==false))|sort_by(.created_at)|reverse|.[1].tag_name // ""')"
+          # Resolve the commit SHA behind the tag (handles annotated tags)
+          SHA="$(gh api repos/$REPO/commits/$TAG --jq .sha)"
           echo "tag=$TAG"  >> "$GITHUB_OUTPUT"
           echo "prev=$PREV" >> "$GITHUB_OUTPUT"
           echo "sha=$SHA"  >> "$GITHUB_OUTPUT"
 
       - name: Generate evidence
         id: gen
+        env:
+          REPO: ${{ github.repository }}
+          TAG:  ${{ steps.meta.outputs.tag }}
+          PREV: ${{ steps.meta.outputs.prev }}
+          SHA:  ${{ steps.meta.outputs.sha }}
         shell: bash
         run: |
           set -euo pipefail
-          REPO="${GITHUB_REPOSITORY}"
-          TAG="${{ steps.meta.outputs.tag }}"
-          PREV="${{ steps.meta.outputs.prev }}"
-          SHA="${{ steps.meta.outputs.sha }}"
           OUT="release-evidence-$TAG.md"
 
-          # Pull core release fields via gh release view (robust by tag, no 404s)
           gh release view "$TAG" -R "$REPO" \
-            --json name,tagName,publishedAt,author,url \
-            > /tmp/release.json
+            --json name,tagName,publishedAt,author,url > /tmp/release.json
 
           {
             echo "# Release Evidence for $TAG"


### PR DESCRIPTION
- **ci: robust release evidence (resolve commit sha; avoid /releases/tags 404)**
- **ci: fix actions runs query (use commit SHA; list via gh run); avoid 404**
